### PR TITLE
Change API to separate thread-safe contexts

### DIFF
--- a/ZstdNet/CompressionOptions.cs
+++ b/ZstdNet/CompressionOptions.cs
@@ -16,6 +16,8 @@ namespace ZstdNet
 
 			if (dict != null)
 				Cdict = ExternMethods.ZSTD_createCDict(dict, (size_t)dict.Length, compressionLevel).EnsureZstdSuccess();
+			else
+				GC.SuppressFinalize(this); // No unmanaged resources
 		}
 
 		public CompressionOptions(int compressionLevel)

--- a/ZstdNet/CompressionOptions.cs
+++ b/ZstdNet/CompressionOptions.cs
@@ -1,0 +1,63 @@
+﻿using System;
+#if BUILD64
+using size_t = System.UInt64;
+#else
+using size_t = System.UInt32;
+#endif
+
+namespace ZstdNet
+{
+	public class CompressionOptions
+	{
+		public CompressionOptions(byte[] dict, int compressionLevel = DefaultCompressionLevel)
+			: this(compressionLevel)
+		{
+			Dictionary = dict;
+
+			if (dict != null)
+				Cdict = ExternMethods.ZSTD_createCDict(dict, (size_t)dict.Length, compressionLevel).EnsureZstdSuccess();
+		}
+
+		public CompressionOptions(int compressionLevel)
+		{
+			CompressionLevel = compressionLevel;
+		}
+
+		~CompressionOptions()
+		{
+			Dispose(false);
+		}
+
+		public void Dispose()
+		{
+			Dispose(true);
+		}
+
+		private void Dispose(bool disposing)
+		{
+			if (disposed)
+				return;
+			disposed = true;
+
+			if (Cdict != IntPtr.Zero)
+				ExternMethods.ZSTD_freeCDict(Cdict);
+
+			if (disposing)
+				GC.SuppressFinalize(this);
+		}
+
+		private bool disposed = false;
+
+		public static int MaxCompressionLevel
+		{
+			get { return ExternMethods.ZSTD_maxCLevel(); }
+		}
+
+		public const int DefaultCompressionLevel = 3; // Used by zstd utility by default
+
+		public readonly int CompressionLevel;
+		public readonly byte[] Dictionary;
+
+		internal readonly IntPtr Cdict;
+	}
+}

--- a/ZstdNet/DecompressionOptions.cs
+++ b/ZstdNet/DecompressionOptions.cs
@@ -15,6 +15,8 @@ namespace ZstdNet
 
 			if (dict != null)
 				Ddict = ExternMethods.ZSTD_createDDict(dict, (size_t)dict.Length).EnsureZstdSuccess();
+			else
+				GC.SuppressFinalize(this); // No unmanaged resources
 		}
 
 		~DecompressionOptions()

--- a/ZstdNet/DecompressionOptions.cs
+++ b/ZstdNet/DecompressionOptions.cs
@@ -1,0 +1,49 @@
+﻿using System;
+#if BUILD64
+using size_t = System.UInt64;
+#else
+using size_t = System.UInt32;
+#endif
+
+namespace ZstdNet
+{
+	public class DecompressionOptions
+	{
+		public DecompressionOptions(byte[] dict)
+		{
+			Dictionary = dict;
+
+			if (dict != null)
+				Ddict = ExternMethods.ZSTD_createDDict(dict, (size_t)dict.Length).EnsureZstdSuccess();
+		}
+
+		~DecompressionOptions()
+		{
+			Dispose(false);
+		}
+
+		public void Dispose()
+		{
+			Dispose(true);
+		}
+
+		private void Dispose(bool disposing)
+		{
+			if (disposed)
+				return;
+			disposed = true;
+
+			if (Ddict != IntPtr.Zero)
+				ExternMethods.ZSTD_freeDDict(Ddict);
+
+			if (disposing)
+				GC.SuppressFinalize(this);
+		}
+
+		private bool disposed = false;
+
+		public readonly byte[] Dictionary;
+
+		internal readonly IntPtr Ddict;
+	}
+}

--- a/ZstdNet/ZstdNet.csproj
+++ b/ZstdNet/ZstdNet.csproj
@@ -53,7 +53,9 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ArraySegmentPtr.cs" />
+    <Compile Include="CompressionOptions.cs" />
     <Compile Include="Compressor.cs" />
+    <Compile Include="DecompressionOptions.cs" />
     <Compile Include="Decompressor.cs" />
     <Compile Include="DictBuilder.cs" />
     <Compile Include="ExternMethods.cs" />


### PR DESCRIPTION
`Compressor` and `Decompressor` classes aren't thread-safe, but `cdict` and `ddict` ("digested" dictionaries) in them are. The new API extracts them to `CompressionOptions` and `DecompressionOptions` classes, that can be shared across threads to avoid performance and memory overhead.

Also, more detailed reference for the new API has been added.
