### PR TITLE
Changing the platform specific location of the dll to bin\libzstd.dll

### DIFF
--- a/ZstdNet/build/ZstdNet.targets
+++ b/ZstdNet/build/ZstdNet.targets
@@ -2,11 +2,11 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)x64\libzstd.dll" Condition="'$(Platform)' == 'x64' OR '$(Platform)' == 'AnyCPU'">
-      <Link>x64\%(FileName)%(Extension)</Link>
+      <Link>%(FileName)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="$(MSBuildThisFileDirectory)x86\libzstd.dll" Condition="'$(Platform)' == 'x86' OR '$(Platform)' == 'AnyCPU'">
-      <Link>x86\%(FileName)%(Extension)</Link>
+    <None Include="$(MSBuildThisFileDirectory)x86\libzstd.dll" Condition="'$(Platform)' == 'x86'">
+      <Link>%(FileName)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>


### PR DESCRIPTION
instead of bin\x64\libzstd.dll and bin\x86\libzstd.dll this will copy the platform specific dll to the bin folder. 
